### PR TITLE
WR-424432: Add null privacy provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -18,23 +18,20 @@
  * This file explains this plugins status in relation to the GDPR.
  *
  * @package    block_courses_by_role
- * @copyright  2018 tim@avide.com.au
+ * @copyright  2018 tim@avide.com.au, 2023 djarrancotleanu@catalyst-au.net
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+namespace block_courses_by_role\privacy;
 
 /**
  * A provider class to address GDPR
  *
  * @package    block_courses_by_role
- * @copyright  2018 tim@avide.com.au
+ * @copyright  2018 tim@avide.com.au, 2023 djarrancotleanu@catalyst-au.net
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements \core_privacy\local\metadata\null_provider {
-
-    // Support PHP back to 5.6 (for Moodle 3.3 and lower).
-    use \core_privacy\local\legacy_polyfill;
 
     /**
      * Get the language string identifier from the component's language
@@ -42,7 +39,8 @@ class provider implements \core_privacy\local\metadata\null_provider {
      *
      * @return string
      */
-    public static function _get_reason() {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }
+

--- a/lang/en/block_courses_by_role.php
+++ b/lang/en/block_courses_by_role.php
@@ -34,3 +34,4 @@ $string['labels_desc'] = "Rather than using the role shortname, when matched use
 $string['roles'] = 'Include roles';
 $string['roles_desc'] = 'Limit the display to users only in these roles (select-multiple if required)';
 $string['privacy:metadata'] = 'The courses_by_role plugin does not store any personal data.';
+

--- a/lang/en/block_courses_by_role.php
+++ b/lang/en/block_courses_by_role.php
@@ -33,3 +33,4 @@ $string['labels_desc'] = "Rather than using the role shortname, when matched use
 	";
 $string['roles'] = 'Include roles';
 $string['roles_desc'] = 'Limit the display to users only in these roles (select-multiple if required)';
+$string['privacy:metadata'] = 'The courses_by_role plugin does not store any personal data.';


### PR DESCRIPTION
Plugin already contained a privacy provider, however it was using a previous implementation that no longer works. This was updated to use a newer method for the null privacy provider. 